### PR TITLE
Metadata and modernization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@hashicorp/team-selfmanaged-releng

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels: []

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions-breaking:
+        update-types:
+          - major
+      github-actions-backward-compatible:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions-breaking:
+        update-types:
+          - major
+      github-actions-backward-compatible:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,19 @@
+name: Lint GitHub Actions Workflows
+
+on:
+  push:
+    paths:
+      - .github/**
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: "Check workflow files"
+        uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest
+        with:
+          args: -color

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+    paths:
+      - "**"
+      - "!**.md"
+      - "!.github/**"
+
+jobs:
+
+  go-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: go.mod
+          cache: false
+      - run: make test

--- a/META.d/README.md
+++ b/META.d/README.md
@@ -1,0 +1,3 @@
+# Reliability Data Platform Information
+
+These documents are meant to feed [heimdall](https://heimdall.hashicorp.services/site/), the Reliability Data Platform. A detailed breakdown of the schema can be found [here](https://github.com/hashicorp/core-sre-heimdall-core/blob/main/docs/SCHEMA.md).

--- a/META.d/_summary.yaml
+++ b/META.d/_summary.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+schema: 1.1
+
+partition: release-engineering
+category: github-action
+
+summary:
+  name: composite-action-framework
+  owner: team-selfmanaged-releng
+  description: A library of packages for writing _composite_ GitHub Actions in Go.
+  visibility: external
+  auth_methods: none

--- a/META.d/links.yaml
+++ b/META.d/links.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+runbooks: []
+  # - name: runbook name
+  #   link: link to runbook
+
+other_links:
+  - name: Reproducible Builds RFC
+    link: hhttps://go.hashi.co/rfc/engsrv-084

--- a/META.d/tags.yaml
+++ b/META.d/tags.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+tags:
+  family: github-actions
+  type: github-action
+  crt-compatible: true
+  exempt: tool-roam-config

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/composite-action-framework-go
 
-go 1.18
+go 1.24
 
 require (
 	github.com/go-git/go-git/v5 v5.5.0


### PR DESCRIPTION
This repo is a dependency for actions-go-build.  It somehow slipped past scans for things like ownership and hasn't seen updates for years. 😿 

* Add CODEOWNERS
* Add META.d for heimdall
* Bump Go version
* Add basic self-test workflows: actionlint, go tests
* Configure dependabot

This last is expected to yield additional PRs for dependency updates...